### PR TITLE
Retry mongo WriteConflict in coordinator transactions (SYN-38)

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
@@ -10,6 +11,29 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 )
+
+// transientTransactionErrorLabel is attached by the mongo driver to errors
+// that are safe to retry by re-running the whole transaction (e.g. a
+// WriteConflict raised on a write inside a transaction). WithTransaction
+// retries on this label automatically.
+const transientTransactionErrorLabel = "TransientTransactionError"
+
+// IsTransientTransactionError reports whether err is a transient mongo
+// transaction error (such as a WriteConflict) that Tx/WithTransaction will
+// retry. Callers that translate mongo errors into their own sentinel errors
+// must propagate such errors unchanged, otherwise the retry cannot happen
+// (see SYN-38).
+func IsTransientTransactionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Both mongo.CommandError and mongo.WriteException expose HasErrorLabel.
+	var labeler interface{ HasErrorLabel(string) bool }
+	if errors.As(err, &labeler) {
+		return labeler.HasErrorLabel(transientTransactionErrorLabel)
+	}
+	return false
+}
 
 const CName = "coordinator.db"
 
@@ -58,23 +82,17 @@ func (d *database) Tx(ctx context.Context, f func(txCtx mongo.SessionContext) er
 	return client.UseSessionWithOptions(
 		ctx,
 		options.Session().SetDefaultReadConcern(readconcern.Majority()),
-		func(txCtx mongo.SessionContext) error {
-			if err := txCtx.StartTransaction(); err != nil {
-				return err
-			}
-
-			if err := f(txCtx); err != nil {
-				// Abort the transaction after an error. Use
-				// context.Background() to ensure that the abort can complete
-				// successfully even if the context passed to mongo.WithSession
-				// is changed to have a timeout.
-				_ = txCtx.AbortTransaction(context.Background())
-				return err
-			}
-
-			// Use context.Background() to ensure that the commit can complete
-			// successfully even if the context passed to mongo.WithSession is
-			// changed to have a timeout.
-			return txCtx.CommitTransaction(context.Background())
+		func(sessCtx mongo.SessionContext) error {
+			// WithTransaction transparently retries the whole callback on
+			// transient errors (e.g. mongo WriteConflict, labeled
+			// TransientTransactionError) and retries the commit on
+			// UnknownTransactionCommitResult, with backoff and a safety
+			// deadline. This is the mongo-recommended retry loop; without it
+			// a WriteConflict under concurrency fails the caller instead of
+			// being retried (see SYN-38).
+			_, err := sessCtx.WithTransaction(ctx, func(txCtx mongo.SessionContext) (interface{}, error) {
+				return nil, f(txCtx)
+			})
+			return err
 		})
 }

--- a/db/db.go
+++ b/db/db.go
@@ -21,8 +21,7 @@ const transientTransactionErrorLabel = "TransientTransactionError"
 // IsTransientTransactionError reports whether err is a transient mongo
 // transaction error (such as a WriteConflict) that Tx/WithTransaction will
 // retry. Callers that translate mongo errors into their own sentinel errors
-// must propagate such errors unchanged, otherwise the retry cannot happen
-// (see SYN-38).
+// must propagate such errors unchanged, otherwise the retry cannot happen.
 func IsTransientTransactionError(err error) bool {
 	if err == nil {
 		return false
@@ -89,7 +88,7 @@ func (d *database) Tx(ctx context.Context, f func(txCtx mongo.SessionContext) er
 			// UnknownTransactionCommitResult, with backoff and a safety
 			// deadline. This is the mongo-recommended retry loop; without it
 			// a WriteConflict under concurrency fails the caller instead of
-			// being retried (see SYN-38).
+			// being retried.
 			_, err := sessCtx.WithTransaction(ctx, func(txCtx mongo.SessionContext) (interface{}, error) {
 				return nil, f(txCtx)
 			})

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestIsTransientTransactionError(t *testing.T) {
+	writeConflict := mongo.CommandError{
+		Code:    112,
+		Name:    "WriteConflict",
+		Message: "Please retry your operation or multi-document transaction.",
+		Labels:  []string{transientTransactionErrorLabel},
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		assert.False(t, IsTransientTransactionError(nil))
+	})
+	t.Run("command error with label", func(t *testing.T) {
+		assert.True(t, IsTransientTransactionError(writeConflict))
+	})
+	t.Run("wrapped command error with label", func(t *testing.T) {
+		assert.True(t, IsTransientTransactionError(fmt.Errorf("syncWithPeer: %w", writeConflict)))
+	})
+	t.Run("write exception with label", func(t *testing.T) {
+		we := mongo.WriteException{Labels: []string{transientTransactionErrorLabel}}
+		assert.True(t, IsTransientTransactionError(we))
+	})
+	t.Run("command error without label", func(t *testing.T) {
+		other := mongo.CommandError{Code: 11000, Name: "DuplicateKey"}
+		assert.False(t, IsTransientTransactionError(other))
+	})
+	t.Run("plain error", func(t *testing.T) {
+		assert.False(t, IsTransientTransactionError(errors.New("boom")))
+	})
+	t.Run("no documents", func(t *testing.T) {
+		assert.False(t, IsTransientTransactionError(mongo.ErrNoDocuments))
+	})
+}

--- a/spacestatus/spacestatus.go
+++ b/spacestatus/spacestatus.go
@@ -395,7 +395,7 @@ func (s *spaceStatus) modifyStatus(ctx context.Context, change StatusChange, old
 	if res.Err() != nil {
 		// A WriteConflict (or other transient transaction error) must be
 		// propagated with its label intact so the enclosing Tx can retry it;
-		// it does not mean the status precondition failed (see SYN-38).
+		// it does not mean the status precondition failed.
 		if db.IsTransientTransactionError(res.Err()) {
 			return StatusEntry{}, res.Err()
 		}
@@ -604,7 +604,7 @@ func notFoundOrUnexpected(err error) error {
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return coordinatorproto.ErrSpaceNotExists
 	} else if db.IsTransientTransactionError(err) {
-		// keep the retry label so the enclosing Tx can retry (SYN-38)
+		// keep the retry label so the enclosing Tx can retry
 		return err
 	} else {
 		log.Info("unexpected error received", zap.Error(err))
@@ -614,7 +614,7 @@ func notFoundOrUnexpected(err error) error {
 
 // unexpectedOrTransient preserves a transient transaction error (e.g. a mongo
 // WriteConflict) so the enclosing Tx can retry it, while mapping any other
-// error to the generic ErrUnexpected sentinel (see SYN-38).
+// error to the generic ErrUnexpected sentinel.
 func unexpectedOrTransient(err error) error {
 	if db.IsTransientTransactionError(err) {
 		return err

--- a/spacestatus/spacestatus.go
+++ b/spacestatus/spacestatus.go
@@ -188,11 +188,11 @@ func (s *spaceStatus) AccountDelete(ctx context.Context, payload AccountDeletion
 			Identity: identity,
 		})
 		if err != nil {
-			return coordinatorproto.ErrUnexpected
+			return unexpectedOrTransient(err)
 		}
 		var spaces []StatusEntry
 		if err = cursor.All(txCtx, &spaces); err != nil {
-			return coordinatorproto.ErrUnexpected
+			return unexpectedOrTransient(err)
 		}
 
 		// Iterate through the spaces and call setStatusTx
@@ -237,11 +237,11 @@ func (s *spaceStatus) AccountRevertDeletion(ctx context.Context, payload Account
 			Identity: identity,
 		})
 		if err != nil {
-			return coordinatorproto.ErrUnexpected
+			return unexpectedOrTransient(err)
 		}
 		var spaces []StatusEntry
 		if err = cursor.All(txCtx, &spaces); err != nil {
-			return coordinatorproto.ErrUnexpected
+			return unexpectedOrTransient(err)
 		}
 
 		// Iterate through the spaces and call setStatusTx
@@ -270,6 +270,9 @@ func (s *spaceStatus) SpaceDelete(ctx context.Context, payload SpaceDeletion) (t
 	err = s.db.Tx(ctx, func(txCtx mongo.SessionContext) error {
 		spType, err := s.getSpaceTypeTx(txCtx, payload.SpaceId)
 		if err != nil {
+			if db.IsTransientTransactionError(err) {
+				return err
+			}
 			return coordinatorproto.ErrSpaceNotExists
 		}
 		switch spType {
@@ -390,6 +393,12 @@ func (s *spaceStatus) modifyStatus(ctx context.Context, change StatusChange, old
 		Identity: encodedIdentity,
 	}, op, options.FindOneAndUpdate().SetReturnDocument(options.After))
 	if res.Err() != nil {
+		// A WriteConflict (or other transient transaction error) must be
+		// propagated with its label intact so the enclosing Tx can retry it;
+		// it does not mean the status precondition failed (see SYN-38).
+		if db.IsTransientTransactionError(res.Err()) {
+			return StatusEntry{}, res.Err()
+		}
 		curStatus, err := s.Status(ctx, change.SpaceId)
 		if err != nil {
 			return StatusEntry{}, notFoundOrUnexpected(err)
@@ -594,10 +603,23 @@ func (s *spaceStatus) Close(ctx context.Context) (err error) {
 func notFoundOrUnexpected(err error) error {
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return coordinatorproto.ErrSpaceNotExists
+	} else if db.IsTransientTransactionError(err) {
+		// keep the retry label so the enclosing Tx can retry (SYN-38)
+		return err
 	} else {
 		log.Info("unexpected error received", zap.Error(err))
 		return coordinatorproto.ErrUnexpected
 	}
+}
+
+// unexpectedOrTransient preserves a transient transaction error (e.g. a mongo
+// WriteConflict) so the enclosing Tx can retry it, while mapping any other
+// error to the generic ErrUnexpected sentinel (see SYN-38).
+func unexpectedOrTransient(err error) error {
+	if db.IsTransientTransactionError(err) {
+		return err
+	}
+	return coordinatorproto.ErrUnexpected
 }
 
 func incorrectStatusError(curStatus int) (err error) {


### PR DESCRIPTION
## Summary

During head-sync, concurrent writes to mongo can raise a transient `WriteConflict` (WiredTiger: *"Please retry your operation or multi-document transaction"*). The coordinator's `db.Tx` hand-rolled the transaction lifecycle (`StartTransaction` → callback → `Commit`) with **no retry**, so the conflict failed the caller instead of being retried — intermittently stalling space cold-sync (a freshly-joined member / second device sees a space with no metadata and `OwnRole: none`).

Fixes [SYN-38](https://linear.app/anyorg/issue/SYN-38).

## Changes

**`db/db.go`**
- `db.Tx` now uses the driver's `Session.WithTransaction`, which retries the callback on `TransientTransactionError` (`WriteConflict`) and retries the commit on `UnknownTransactionCommitResult`, with backoff and a safety deadline. This is the mongo-recommended retry loop and covers all 8 transactional write paths.
- Added `db.IsTransientTransactionError` helper (matches `CommandError`/`WriteException` labels, unwraps).

**`spacestatus/spacestatus.go`**
Retry only works if the transient label survives to `WithTransaction`. Fixed the paths that swallowed it into business sentinels:
- `modifyStatus` — `FindOneAndUpdate` (where `WriteConflict` surfaces) no longer assumes any error means "wrong status"; transient errors are propagated so the txn retries.
- `notFoundOrUnexpected`, the `Find`/`cursor.All` conversions in `AccountDelete`/`AccountRevertDeletion`, and the `getSpaceTypeTx` caller in `SpaceDelete` now preserve transient errors (via new `unexpectedOrTransient`).

**Tests**
- `db/db_test.go` — unit test for `IsTransientTransactionError` (no mongo required).

## Testing
- `go build ./...` ✅
- `go test ./db/...` ✅
- `go test ./spacestatus/...` ✅ (against local mongo)

## Notes / scope
- `accountStatusFindTx` returns a bare `bool`; a conflict on that *read* (rare under majority read concern) still surfaces as `false`. Left unchanged to avoid a signature change across 3 callers — the dominant conflict points (write + commit) are covered.
- `ChangeOwner` does a single non-transactional `UpdateOne`, already covered by the driver's retryable-writes.
- The head-sync RPC in the report is served by **any-sync-node**, which has no mongo of its own — it stores locally and proxies space status/consensus to the coordinator. The `WriteConflict` seen during head-sync therefore originates in the coordinator's mongo and is relayed back over the node's RPC, so this PR closes the reported stall at the source; no any-sync-node follow-up is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
